### PR TITLE
HDA-6845 [라이브러리] [workflow 재사용] JIRA release

### DIFF
--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -1,0 +1,26 @@
+name: Jira Release
+on:
+  workflow_call:
+    inputs:
+      jira_version_prefix:
+        required: true
+        type: string
+    secrets:
+      jira_auth_token:
+        required: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 버전 정보 추출
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+      - name: Jira Release
+        id: release
+        uses: PRNDcompany/jira-release@v1.3
+        with:
+          domain: prndcompany
+          project: HDA
+          version: ${{ inputs.jira_version_prefix }} ${{ steps.extract_version_name.outputs.version }}
+          auth-token: ${{ secrets.jira_auth_token }}


### PR DESCRIPTION
## 개요
workflow를 재사용하기 위한 용도의 repository를 새로 만들고 이곳에 중복되는 workflow들을 모두 옮겨놓을 예정입니다.
가장 먼저 `jira_release.yml` 부터 진행했습니다.

## 반영화면
외부로 드러나면 안되는 부분들이 있어서 반영 화면은 아래 PR에서 확인하실 수 있습니다.

https://github.com/PRNDcompany/heydealer-android/pull/4050