### PR TITLE
HDA-6868 [공통] [workflow 재사용] 단위 테스트

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,18 @@
+name: Unit Test
+on:
+  workflow_call:
+    secrets:
+      personal_access_token:
+        required: true
+jobs:
+  unit-test:
+    runs-on: Android # self-hosted runner
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.personal_access_token }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build with Gradle
+        run: ./gradlew clean checkDebugUnitTest


### PR DESCRIPTION
## 개요
모든 repository에 중복되어있는 단위테스트 workflow를 분리합니다.
personal_access_token만 받아서 checkout 하는 방식으로 변경하였습니다.

각 앱 repository에서는 main 브랜치를 참조하도록 만들어야해서 해당 PR 병합 후 다시 리뷰요청드리겠습니다.

## 반영화면
https://github.com/PRNDcompany/heydealer-android/actions/runs/3318369652/jobs/5482813702