### PR TITLE
HDA-6869 [공통] [workflow 재사용] release, tag 생성

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -1,0 +1,21 @@
+name: Release Tag
+on:
+  workflow_call:
+    secrets:
+      GITHUB_AUTH_TOKEN:
+        required: true
+jobs:
+  release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 버전 정보 추출
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+      - name: Release 생성
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_AUTH_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version_name.outputs.version }}
+          release_name: ${{ steps.extract_version_name.outputs.version }}


### PR DESCRIPTION
## 개요
재사용할 수 있는 release, tag 생성하는 workflow를 추가합니다.
`GITHUB_TOKEN`은 예약어여서 `GITHUB_AUTH_TOKEN`을 통해서 token을 받도록 만들었습니다.

## 반영화면
이 workflow를 통해서 만들어진 tag, release는 모두 제거했습니다.

https://github.com/PRNDcompany/heydealer-android/actions/runs/3367027271
