### PR TITLE
HDA-6974 [공통] 단위테스트에서 clean 제거

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Build with Gradle
-        run: ./gradlew clean checkDebugUnitTest
+        run: ./gradlew checkDebugUnitTest


### PR DESCRIPTION
## 개요
actions/checkout Action에서 이미 clean을 하고 있기 때문에 불필요한 작업이어서 제거합니다.