### PR TITLE
HDA-6975 [공통] [workflow 재사용] secrets 변수 이름들을 컨벤션에 따라 SCREAMING_SNAKE_CASE로 변경

### DIFF
--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
     secrets:
-      jira_auth_token:
+      JIRA_AUTH_TOKEN:
         required: true
 jobs:
   build:
@@ -23,4 +23,4 @@ jobs:
           domain: prndcompany
           project: HDA
           version: ${{ inputs.jira_version_prefix }} ${{ steps.extract_version_name.outputs.version }}
-          auth-token: ${{ secrets.jira_auth_token }}
+          auth-token: ${{ secrets.JIRA_AUTH_TOKEN }}

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -11,8 +11,6 @@ on:
     secrets:
       JIRA_AUTH_TOKEN:
         required: true
-      GITHUB_AUTH_TOKEN: # GITHUB_TOKEN 예약어와의 충돌 회피
-        required: true
 jobs:
   pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -9,9 +9,9 @@ on:
         type: string
         default: "main"
     secrets:
-      jira_auth_token:
+      JIRA_AUTH_TOKEN:
         required: true
-      github_auth_token: # github_token 예약어와의 충돌 회피
+      GITHUB_AUTH_TOKEN: # GITHUB_TOKEN 예약어와의 충돌 회피
         required: true
 jobs:
   pull-request:
@@ -28,13 +28,13 @@ jobs:
           domain: prndcompany
           project: HDA
           version: ${{ inputs.jira_version_prefix }} ${{ steps.extract_version.outputs.version }}
-          auth-token: ${{ secrets.jira_auth_token }}
+          auth-token: ${{ secrets.JIRA_AUTH_TOKEN }}
       - name: Release PR 생성 (main)
         id: create_pr
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: ${{ inputs.main_branch_name }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
@@ -42,7 +42,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "develop"
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"

--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -6,9 +6,9 @@ on:
         required: true
         type: string
     secrets:
-      jira_auth_token:
+      JIRA_AUTH_TOKEN:
         required: true
-      github_auth_token: # github_token 예약어와의 충돌 회피
+      GITHUB_AUTH_TOKEN: # github_token 예약어와의 충돌 회피
         required: true
 jobs:
   pr_update:
@@ -25,11 +25,11 @@ jobs:
           domain: prndcompany
           project: HDA
           version: ${{ inputs.jira_version_prefix }} ${{ steps.extract_version.outputs.version }}
-          auth-token: ${{ secrets.jira_auth_token }}
+          auth-token: ${{ secrets.JIRA_AUTH_TOKEN }}
       - name: PR 업데이트
         uses: tzkhan/pr-update-action@v2
         with:
-          repo-token: "${{ secrets.github_token }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           base-branch-regex: "master"
           head-branch-regex: 'release\/|hotfix\/'
           body-template: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"

--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -8,8 +8,6 @@ on:
     secrets:
       JIRA_AUTH_TOKEN:
         required: true
-      GITHUB_AUTH_TOKEN: # github_token 예약어와의 충돌 회피
-        required: true
 jobs:
   pr_update:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -1,9 +1,6 @@
 name: Release Tag
 on:
   workflow_call:
-    secrets:
-      GITHUB_AUTH_TOKEN:
-        required: true
 jobs:
   release-tag:
     runs-on: ubuntu-latest
@@ -15,7 +12,7 @@ jobs:
       - name: Release 생성
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_AUTH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.extract_version_name.outputs.version }}
           release_name: ${{ steps.extract_version_name.outputs.version }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -2,7 +2,7 @@ name: Unit Test
 on:
   workflow_call:
     secrets:
-      personal_access_token:
+      PERSONAL_ACCESS_TOKEN:
         required: true
 jobs:
   unit-test:
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-          token: ${{ secrets.personal_access_token }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Build with Gradle


### PR DESCRIPTION
공식 문서에 명확하게 나와있는건 없지만 Github Action에서 secrets은 SCREAMING_SNAKE_CASE가 사실상 표준으로 보여서 모두 수정했습니다.

추가로 GITHUB_TOKEN이 secrets로 그대로 넘어오고 있어서 불필요하게 GITHUB_AUTH_TOKEN을 넘기고 사용하는 부분들을 모두 제거했습니다.