### PR TITLE
HDA-7438 [공통] master 브랜치를 main 브랜치로 전환

### DIFF
--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -28,7 +28,7 @@ jobs:
         uses: tzkhan/pr-update-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          base-branch-regex: "master"
+          base-branch-regex: "main"
           head-branch-regex: 'release\/|hotfix\/'
           body-template: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
           body-update-action: "replace"


### PR DESCRIPTION
## 개요

최초에 만들 때, 외부에서 main, master인지를 받고 처리해야 했는데 master로 고정되어 있었습니다.
앞으로 master를 쓰지 않을 예정이니 main 브랜치로 고정합니다.