### PR TITLE
HDA-7432 [공통][GitHub Action 마이그레이션] debug 빌드

### DIFF
--- a/.github/workflows/build_debug_app.yml
+++ b/.github/workflows/build_debug_app.yml
@@ -1,0 +1,18 @@
+name: debug 앱 빌드
+on:
+  workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+jobs:
+  build-debug-app:
+    runs-on: migration # self-hosted runner
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
debug 빌드를 수행하는 workflow를 추가합니다.
cache까지 처리하는 setup-java까지 추가하려다가 캐시 처리를 제대로 하려면 꽤나 복잡해서 일단은 제거해두었습니다.

현재 사용중인 `Android` runner에 영향이 가지 않도록 임시로 사용할 `migration` runner는 각 앱 repository에 하나씩 만들어두었습니다.
