### PR TITLE
HDA-8054 [공통][GitHub Action 마이그레이션 2차] 기존 작업이 끝나지 않은 상태에서 새로운 작업이 시작되면 이전 작업 취소

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -1,4 +1,7 @@
 name: 앱 빌드
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,7 @@
 name: Unit Test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
GitHub Action에서 concurrency group을 같은 group으로 지정하면 동시에 하나만 수행하도록 만들 수 있습니다. 
동시성 그룹은 아래와 같이 설정합니다.

1. workflow 별로 따로따로 체크한다. (단위 테스트, 앱 빌드)
2. PR이면 PR 번호를 기준으로 따로 체크한다.
3. PR이 아니면 refs를 기준으로 따로 체크한다.

새로운 작업이 추가되었을 때, 기존 작업을 계속해서 수행할 필요가 없기 때문에 cancel-in-progress를 true로 처리합니다.

## 반영 화면
https://github.com/PRNDcompany/heydealer-call-android/actions/runs/4101503008