### PR TITLE
HDA-8840 [공통] [GitHub Action] release_pr_create 에서 pr_assignee 제거

### DIFF
--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           destination_branch: ${{ inputs.main_branch_name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
       - name: Release PR 생성 (develop)
@@ -41,6 +40,5 @@ jobs:
         with:
           destination_branch: "develop"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"


### PR DESCRIPTION
- PR을 자동으로 만들어 줄때 assignee를 마지막 커밋한 author의 정보로 지정하고 있음
- branch를 자동으로 만들어주는 작업을 하는 작업을 하게 된다면 author는 Github Actions가 되는데 유효하지 않은 assignee가 되어서 오류가 발생함
- 꼭 assignee를 지정해줄 필요도 없기 때문에 해당 파라미터 제거