### PR TITLE
HDA-6873 [공통] [workflow 재사용] develop PR 병합

### DIFF
--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -22,6 +22,11 @@ jobs:
       env:
         number: ${{ steps.find_pr.outputs.number }}
         sha: ${{ steps.find_pr.outputs.head-sha }}
+    - name: Approve Pull Request
+      uses: juliangruber/approve-pull-request-action@v2.0.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        number: ${{ steps.find_pr.outputs.number }}
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1
       with:

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -1,0 +1,30 @@
+name: Release PR develop merge
+
+on:
+  workflow_call:
+
+jobs:
+  pr_develop_merge:
+    # Release PR이 merge 되었을때만 develop으로 자동 merge
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Release branch 추출
+      run: echo ::set-output name=branch::${GITHUB_HEAD_REF}
+      id: extract_branch
+    - name: PR 찾기
+      uses: juliangruber/find-pull-request-action@v1
+      id: find_pr
+      with:
+        branch: ${{ steps.extract_branch.outputs.branch }}
+    - run: echo "Pull Request ${number} (${sha})"
+      env:
+        number: ${{ steps.find_pr.outputs.number }}
+        sha: ${{ steps.find_pr.outputs.head-sha }}
+    - name: Merge Pull Request
+      uses: juliangruber/merge-pull-request-action@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        number: ${{ steps.find_pr.outputs.number }}
+        method: merge


### PR DESCRIPTION
## 개요
develop 브랜치를 target으로 하는 PR을 자동으로 병합하는 workflow를 추가합니다.
추가로 기존에 실패했던 것까지 해결해두었습니다.

기존에 실패하던 이유는 branch protection rule에서 최소 하나의 Approve가 필요해서 실패했습니다.
따라서 자동으로 Approve를 한 다음 Merge를 하면 성공합니다.

## 반영 화면
- https://github.com/olaf-prnd/workflow-test/pull/9
- https://github.com/olaf-prnd/workflow-test/pull/10
- [develop PR 자동 병합 workflow 실행결과](https://github.com/olaf-prnd/workflow-test/pull/10/checks)