### PR TITLE
HDA-9313 [공통] SigningConfig를 GitHub Secret으로 관리

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -7,10 +7,6 @@ on:
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
-      SIGNING_NAME:
-        required: true
-      SIGNING_PASSWORD:
-        required: true
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -7,6 +7,10 @@ on:
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
+      SIGNING_NAME:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
@@ -20,8 +24,19 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
+      - name: Decode KeyStore File
+        run: |
+          KEY_STORE_FILE_PATH=$RUNNER_TEMP/keystore
+          base64 -d -i ${{ secrets.KEY_STORE_FILE }} > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
         run: >
           ./gradlew buildApp
           -P targetBranch="${{ github.base_ref }}"
           -P commentBody="${{ github.event.comment.body }}"
+        env:
+          HEY_DEALER_SIGNING_PATH: $RUNNER_TEMP/keystore
+          HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PATH: $RUNNER_TEMP/keystore
+          HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}


### PR DESCRIPTION
## 개요
SigningConfig에 관련된 속성들을 GitHub Secret으로 관리하기 위한 작업입니다.
먼저 모든 프로젝트가 각각 자신의 signing config에 해당하는 secret을 등록해야 합니다.

- Base64 인코딩된 keystore 파일
- signing name
- signing password

이렇게 등록된 name과 password는 GitHub Action의 secret을 통해 가져올 수 있습니다.
keystore 파일은 Base64로 인코딩되었기 때문에 다시 디코딩 과정을 거친 후에 사용할 수 있어서 디코딩 과정을 거쳐 `_temp` 디렉토리에 저장됩니다.

## 반영화면
- [실행 결과](https://github.com/PRNDcompany/heydealer-inspector-android/actions/runs/5221248044/jobs/9425283632)