### PR TITLE
HDA-9311 [공통] runner마다 각각 다른 GRADLE_USER_HOME을 가지도록 설정

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -25,8 +25,11 @@ jobs:
           KEY_STORE_FILE_PATH=$RUNNER_TEMP/keystore
           base64 -d -i ${{ secrets.KEY_STORE_FILE }} > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
+        # 현재 위치: runner/_work/repo_name/repo_name
+        # gradle user home 위치: runner/.gradle
         run: >
           ./gradlew buildApp
+          --gradle-user-home "../../../.gradle"
           -P targetBranch="${{ github.base_ref }}"
           -P commentBody="${{ github.event.comment.body }}"
         env:


### PR DESCRIPTION
## 개요
gradle user home을 각 runner별로 사용하도록 만들었습니다.

위치가 `runner/_work/repo_name/repo_name` 이기 때문에 gradle user home은 `../../../.gradle`로 설정하여 `runner/.gradle`에 만들었습니다.
