### PR TITLE
HDA-9655 [공통] Signing 오류 수정

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -7,6 +7,12 @@ on:
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
+      KEY_STORE_FILE:
+        required: true
+      SIGNING_NAME:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Decode KeyStore File
+        id: decode_key_store_file
         run: |
-          KEY_STORE_FILE_PATH=$RUNNER_TEMP/keystore
+          KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
+          echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
           base64 -d -i ${{ secrets.KEY_STORE_FILE }} > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
         # 현재 위치: runner/_work/repo_name/repo_name
@@ -33,9 +35,9 @@ jobs:
           -P targetBranch="${{ github.base_ref }}"
           -P commentBody="${{ github.event.comment.body }}"
         env:
-          HEY_DEALER_SIGNING_PATH: $RUNNER_TEMP/keystore
+          HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
           HEY_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          HEY_DEALER_FOR_DEALER_SIGNING_PATH: $RUNNER_TEMP/keystore
+          HEY_DEALER_FOR_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
           HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -22,10 +22,13 @@ jobs:
         uses: android-actions/setup-android@v2
       - name: Decode KeyStore File
         id: decode_key_store_file
+        env: 
+          KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
         run: |
           KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
           echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
-          base64 -d -i ${{ secrets.KEY_STORE_FILE }} > $KEY_STORE_FILE_PATH
+
+          echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle


### PR DESCRIPTION
## 개요

이전 방식으로 빌드가 잘되어서 몰랐는데 3가지 오류가 있었습니다. 😓 

### 잘못된 path
기존에 PATH로 `$RUNNER_TEMP/keystore`를 넘기고 있었는데 상대경로로 처리되어서 잘못된 경로로 keystore 파일을 가져오고 있었습니다.

### 디코딩 실패

base64 명령어의 -i 옵션은 input file을 의미합니다.
```
Usage:	base64 [-hDd] [-b num] [-i in_file] [-o out_file]
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```

기존에는 input 매개변수로 직렬화된 문자열 자체를 넣었는데 그로 인해 잘못 디코딩되고 있었습니다.

### 빈 secret
secret 매개변수로 호출하는 workflow로부터 넘겨받아야하는데 이를 누락해서 빈 값을 쓰고 있었습니다.
지금까지 debug 빌드는 성공했던 이유가 빈 값이 들어가기 때문이었습니다.

## 반영화면
- https://github.com/PRNDcompany/heydealer-android/actions/runs/5553611911/jobs/10142394239?pr=5586
- https://github.com/PRNDcompany/heydealer-for-dealer-android/actions/runs/5553614130/jobs/10142422252?pr=2803