### PR TITLE
HDA-9676 [공통] GitHub Action set-output 마이그레이션

### DIFF
--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Jira Release
         id: release

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "::set-output name=version::$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Release branch 추출
-      run: echo ::set-output name=branch::${GITHUB_HEAD_REF}
+      run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: PR 찾기
       uses: juliangruber/find-pull-request-action@v1

--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "::set-output name=version::$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Release 생성
         uses: actions/create-release@v1


### PR DESCRIPTION
## 개요
2023년 6월 1일에 이미 지원 종료할 예정이었는데 사용하는 사람이 너무 많아서 연기했습니다. ([공식발표](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
지원 종료 일자가 지났으므로 언제 종료할지 모르니 미리 변경해둡니다.

-----

A workflow using save-state or set-output like the following
```yaml
- name: Save state
run: echo "::save-state name={name}::{value}"

- name: Set output
run: echo "::set-output name={name}::{value}"
```

should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files:

```yaml
- name: Save state
run: echo "{name}={value}" >> $GITHUB_STATE

- name: Set output
run: echo "{name}={value}" >> $GITHUB_OUTPUT
```