### PR TITLE
Revert "HDA-9676 [공통] GitHub Action set-output 마이그레이션" [skip-ci]

### DIFF
--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
         id: extract_version_name
       - name: Jira Release
         id: release

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "version=$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=version::$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Release branch 추출
-      run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+      run: echo ::set-output name=branch::${GITHUB_HEAD_REF}
       id: extract_branch
     - name: PR 찾기
       uses: juliangruber/find-pull-request-action@v1

--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "version=$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=version::$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
         id: extract_version_name
       - name: Release 생성
         uses: actions/create-release@v1


### PR DESCRIPTION
## 개요

새로운 방식에 맞춰서 GITHUB_OUTPUT을 마이그레이션하면서 기존 방식과 다르게 변수 값 자체에 특정 문자로 인해 제대로 output이 등록되지 않는 이슈가 있습니다.
다른 방법을 여러가지 시도해보아야 하기 때문에 일단은 모두 정상적으로 동작하는 방식으로 Revert 합니다.