### PR TITLE
HDA-8940 [공통] PR 제목에 skip-ci 가 있으면 무시

### DIFF
--- a/.github/workflows/check_skip.yml
+++ b/.github/workflows/check_skip.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   check-skip:
     runs-on: Android
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false 
+      && !contains(github.event.pull_request.title, 'skip-ci')
     steps:
       - run: echo "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## 개요
[이전](https://github.com/PRNDcompany/prnd-android-workflows/commit/155662057946bcfc936122afc5f3f39ab539aa81)에 `skip-ci`를 붙이는 대신에 draft PR을 만들기로 해서 제목에 `skip-ci`가 있어도 빌드가 되도록 만들었습니다.

그런데 github action workflow을 건드리는 것이나 README.md와 같이 앱 빌드와는 관계가 없는 PR도 merge를 하려면 결국 draft 상태를 풀어야하기 때문에 앱 빌드가 발생해버려서 불필요하게 자원을 쓰게 됩니다.

이 이슈를 막기 위해서 기존처럼 PR 제목에 `skip-ci`를 붙이면 앱을 빌드하지 않도록 만듭니다.

## 반영화면
| draft | skip-ci | draft, skip-ci 둘 다 아닐 때 |
|-|-|-|
| ![draft](https://github.com/PRNDcompany/prnd-android-workflows/assets/85473945/73d49e54-569e-41c2-ad34-a44199b0a6c2) | ![skip-ci](https://github.com/PRNDcompany/prnd-android-workflows/assets/85473945/9ecf0a61-4d21-45f5-a95b-90f4efba406c) | ![draft, skip-ci 둘 다 아닐 때](https://github.com/PRNDcompany/prnd-android-workflows/assets/85473945/7a6caee9-644b-4c2c-a53c-5464f32938fe)
