### PR TITLE
HDA-9367 [공통] develop PR 자동 병합 workflow 수정

### DIFF
--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -3,7 +3,7 @@ name: Release PR develop merge
 on:
   workflow_call:
     secrets:
-      PERSONAL_ACCESS_TOKEN:
+      REVIEWER_ACCESS_TOKEN:
         required: true
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
     - name: Approve Pull Request
       uses: juliangruber/approve-pull-request-action@v2.0.0
       with:
-        github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        github-token: ${{ secrets.REVIEWER_ACCESS_TOKEN }}
         number: ${{ steps.find_pr.outputs.number }}
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1
       with:
-        github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         number: ${{ steps.find_pr.outputs.number }}
         method: merge

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -2,6 +2,9 @@ name: Release PR develop merge
 
 on:
   workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
 
 jobs:
   pr_develop_merge:
@@ -25,11 +28,11 @@ jobs:
     - name: Approve Pull Request
       uses: juliangruber/approve-pull-request-action@v2.0.0
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         number: ${{ steps.find_pr.outputs.number }}
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         number: ${{ steps.find_pr.outputs.number }}
         method: merge


### PR DESCRIPTION
## 개요
develop PR을 GitHub Action이 자동으로 만들도록 해두었는데 이 때문에 GitHub Action이 만든 PR을 GitHub Action이 Approve 할 수 없습니다.
이를 해결하기 위해 외부에서 별도로 Approve만 하기위한 용도의 `REVIEWER_ACCESS_TOKEN`을 받습니다.

## 관련 채널 내용
https://prnd.slack.com/archives/C9UERACB1/p1686318743793699

## 반영 화면
https://github.com/olaf-prnd/workflow-test/pull/39/checks