### PR TITLE
HDA-9785 [공통] GITHUB_OUTPUT 마이그레이션 2차

### DIFF
--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Jira Release
         id: release

--- a/.github/workflows/jira_release.yml
+++ b/.github/workflows/jira_release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Jira Release
         id: release

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "::set-output name=version::$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Release branch 추출
-      run: echo ::set-output name=branch::${GITHUB_HEAD_REF}
+      run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: PR 찾기
       uses: juliangruber/find-pull-request-action@v1

--- a/.github/workflows/release_pr_update.yml
+++ b/.github/workflows/release_pr_update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 버전 정보 추출
-        run: echo "::set-output name=version::$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo ${GITHUB_HEAD_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Jira 릴리즈 노트 추출
         id: release_notes

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Release 생성
         uses: actions/create-release@v1

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 버전 정보 추출
-        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)" >> $GITHUB_OUTPUT
         id: extract_version_name
       - name: Release 생성
         uses: actions/create-release@v1


### PR DESCRIPTION
## 개요
[이전](https://github.com/PRNDcompany/prnd-android-workflows/pull/32) 작업을 그대로 cherry-pick 한 뒤에 [오류만 수정한 commit](https://github.com/PRNDcompany/prnd-android-workflows/commit/975582414301161fb49addef46a62057ca42e3c0)을 추가했습니다.

## 변경된 방식에서 실패하는 원인
변경된 방식에서는 버전이 2개 추출되고 있었습니다.
예를 들어, 이전 명령어에서 commit message만 변경하면 아래의 명령어가 만들어집니다.

```sh
echo "version=$(echo 'Merge pull request #5632 from PRNDcompany/release/6.17.0

Release 6.17.0' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
```

위의 명령어에서 version을 GITHUB_OUTPUT에 넣는 것만 빼고 그대로 터미널에서 실행해보면 버전이 2번 반환된다는걸 바로 알 수 있습니다.
```sh
echo 'Merge pull request #5632 from PRNDcompany/release/6.17.0

Release 6.17.0' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
6.17.0
6.17.0
```

실패하는 경우는 모두 버전이 2개 포함된 commit message를 이용해 버전을 추출하는 경우에 실패하고 GITHUB_REF를 활용하는 경우에는 1개만 반환되므로 성공합니다.

- 실패하는 경우들
  - jira_release.yml: https://github.com/PRNDcompany/heydealer-android/actions/runs/5621612849/job/15232728699
  - release_tag.yml: https://github.com/PRNDcompany/heydealer-android/actions/runs/5621612858/job/15232728674

## 해결방법
1번째 줄만 출력하도록 `head -1`을 추가하여 버전을 제대로 처리하도록 만듭니다.

### as-is
```
echo 'Merge pull request #5632 from PRNDcompany/release/6.17.0

Release 6.17.0' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
6.17.0
6.17.0
```

### to-be
```
echo 'Merge pull request #5632 from PRNDcompany/release/6.17.0

Release 6.17.0' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1
6.17.0
```

## 기존 set-output 방식이 성공하는 이유
위와 똑같이 commit message만 변경해서 명령어를 만들어보면 아래와 같습니다.
```sh
echo "##[set-output name=version;]$(echo 'Merge pull request #5743 from PRNDcompany/release/6.19.0

Release 6.19.0' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
```

위를 실행하면 실패하지 않는걸 볼 수 있습니다.
```sh
##[set-output name=version;]6.19.0
6.19.0
```
여기서 GitHub Action은 첫째줄을 통해 output을 처리하고 2번째 줄부터는 무시되어서 정상적으로 6.19.0이 output으로 처리됩니다.
