### PR TITLE
HDA-10071 [공통] GitHub Action을 통해 PR을 만들어도 앱을 빌드하도록 개선

### DIFF
--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -11,7 +11,7 @@ on:
     secrets:
       JIRA_AUTH_TOKEN:
         required: true
-      CREATOR_ACCESS_TOKEN:
+      PERSONAL_ACCESS_TOKEN:
         required: true
 jobs:
   pull-request:
@@ -34,7 +34,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: ${{ inputs.main_branch_name }}
-          github_token: ${{ secrets.CREATOR_ACCESS_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
@@ -42,7 +42,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "develop"
-          github_token: ${{ secrets.CREATOR_ACCESS_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"

--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -11,6 +11,8 @@ on:
     secrets:
       JIRA_AUTH_TOKEN:
         required: true
+      CREATOR_ACCESS_TOKEN:
+        required: true
 jobs:
   pull-request:
     runs-on: ubuntu-latest
@@ -32,7 +34,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: ${{ inputs.main_branch_name }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CREATOR_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
@@ -40,7 +42,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "develop"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CREATOR_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "Release ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"

--- a/.github/workflows/release_pr_develop_merge.yml
+++ b/.github/workflows/release_pr_develop_merge.yml
@@ -2,9 +2,6 @@ name: Release PR develop merge
 
 on:
   workflow_call:
-    secrets:
-      REVIEWER_ACCESS_TOKEN:
-        required: true
 
 jobs:
   pr_develop_merge:
@@ -28,7 +25,7 @@ jobs:
     - name: Approve Pull Request
       uses: juliangruber/approve-pull-request-action@v2.0.0
       with:
-        github-token: ${{ secrets.REVIEWER_ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         number: ${{ steps.find_pr.outputs.number }}
     - name: Merge Pull Request
       uses: juliangruber/merge-pull-request-action@v1


### PR DESCRIPTION
## 개요
github-actions가 만드는 PR은 workflow event를 트리거하지 않습니다. 
이를 해결하기 위해 별도 계정으로 PR을 생성하도록 변경합니다.

이 작업 이후로 아래와 같이 변경됩니다.

- as-is
  - PR Create: github-actions
  - PR Approve: 별도 계정
- to-be
  - PR Create: 별도 계정
  - PR Approve:  github-actions

## 관련 채널 내용

https://prnd.slack.com/archives/C9UERACB1/p1693969335067949
