### PR TITLE
HDA-10459 [공통][GitHub Action 마이그레이션 3차] 코멘트를 이용한 빌드에서 Check run 생성과 성공 처리

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -1,6 +1,6 @@
 name: 앱 빌드
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 on:
   workflow_call:

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -4,6 +4,10 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ${{ github.ref }}
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
@@ -22,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref }}
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Setup Android SDK

--- a/.github/workflows/build_app_by_comment.yml
+++ b/.github/workflows/build_app_by_comment.yml
@@ -41,6 +41,8 @@ jobs:
   build-app:
     needs: create-check-run
     uses: ./.github/workflows/build_app.yml
+    with:
+      ref: refs/pull/${{ github.event.issue.number }}/merge
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}

--- a/.github/workflows/build_app_by_comment.yml
+++ b/.github/workflows/build_app_by_comment.yml
@@ -1,0 +1,64 @@
+name: 앱 빌드
+on:
+  workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+      KEY_STORE_FILE:
+        required: true
+      SIGNING_NAME:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
+jobs:
+  create-check-run:
+    runs-on: ubuntu-latest
+    outputs:
+      check_run_id: ${{ fromJson(steps.create_check_run.outputs.data).id }}
+    steps:
+      - name: PR 가져오기
+        id: get_pr
+        uses: octokit/request-action@v2.1.9
+        with:
+          route: GET /repos/{repository}/pulls/{pr_number}
+          repository: ${{ github.repository }}
+          pr_number: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: PR의 head_sha 가져오기
+        id: get_head_sha
+        run: echo "head_sha=$(echo ${{ fromJson(steps.get_pr.outputs.data).head.sha }})" >> $GITHUB_OUTPUT
+      - name: Check Run 생성
+        uses: octokit/request-action@v2.1.9
+        id: create_check_run
+        with:
+          route: POST /repos/{repository}/check-runs
+          repository: ${{ github.repository }}
+          name: "build-app-by-comment"
+          head_sha: ${{ steps.get_head_sha.outputs.head_sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-app:
+    needs: create-check-run
+    uses: ./.github/workflows/build_app.yml
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
+      SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+  update-check-run:
+    runs-on: ubuntu-latest
+    needs: [create-check-run, build-app]
+    if: always()
+    steps:
+      - name: Check Run 동기화
+        uses: octokit/request-action@v2.1.9
+        with:
+          route: PATCH /repos/{repository}/check-runs/{check_run_id}
+          repository: ${{ github.repository }}
+          check_run_id: ${{ needs.create-check-run.outputs.check_run_id }}
+          conclusion: ${{ needs.build-app.result }}
+          status: "completed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    


### PR DESCRIPTION
## 개요
`build_app_by_comment.yml`을 통해 빌드하면 코멘트를 남긴 해당 PR의 Check와 연동되지 않습니다.
이는 repository에 설정된 base branch의 `issue_comment` 이벤트를 통해 트리거되기 때문입니다.

이를 해결하기 위해 수동으로 GitHub API를 [Check Run](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28)을 직접 생성하고 업데이트합니다.

## 작업사항

### Check Run 생성, 업데이트
- [HDA-10459 feat: PR Comment를 통해 빌드하면 Check Run을 직접 만들고 업데이트한다](https://github.com/PRNDcompany/prnd-android-workflows/commit/fe72f4d9f9ce12c136d7582bd8b4f41466b1180d)

check run과 관련된 job들은 self-hosted runner에서 수행하지 않고 `ubuntu-latest`에서 처리하도록 만들었습니다.
self-hosted runner는 queue가 꽉 차서 모두 돌아가고 있으면 Check 자체가 만들어지지 않을 수 있습니다.
이를 방지하기 위해 코멘트를 통해 빌드를 한 순간부터 Check에 뜨도록 만들었습니다.

### ref 처리
- [HDA-10459 feat: checkout할 ref를 외부에서 받는다](https://github.com/PRNDcompany/prnd-android-workflows/commit/e23a01a852a4b233954b5be68f4b652f8d99f591)
- [HDA-10459 feat: 코멘트를 남긴 PR의 merge commit을 대상으로 빌드한다](https://github.com/PRNDcompany/prnd-android-workflows/commit/4b5627790dfdd4511de5fc4c0fdd83961b6b8eac)

PR의 이벤트를 통해 트리거되는 경우에는 해당 PR의 merge commit을 대상으로 checkout 합니다.
그런데 `issue_comment`를 통해 트리거되는 경우에는 base branch를 대상으로 checkout 합니다.

PR에 코멘트를 남겨서 빌드하려는 것은 해당 PR을 기준으로 빌드하려는 의도이므로
PR 이벤트를 통해 트리거되는 것처럼 변경합니다.

해당 ref는 github의 [공식문서](https://docs.github.com/ko/actions/learn-github-actions/contexts)에서 참고하였습니다.

> The fully-formed ref of the branch or tag that triggered the workflow run.
For workflows triggered by push, this is the branch or tag ref that was pushed.
**For workflows triggered by pull_request, this is the pull request merge branch.**
For workflows triggered by release, this is the release tag created.
For other triggers, this is the branch or tag ref that triggered the workflow run.
This is only set if a branch or tag is available for the event type.
The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>, **for pull requests it is refs/pull/<pr_number>/merge**, and for tags it is refs/tags/<tag_name>.
For example, refs/heads/feature-branch-1.


### concurrency group 처리
- [HDA-10459 feat: issue_comment를 통해 실행되는 경우 다른 concurrency group을 가진다](https://github.com/PRNDcompany/prnd-android-workflows/commit/3c1e794bb759fe38c4f874a498d2636307b4d6ae)

1번 PR과 2번 PR에서 각각 코멘트를 통해 빌드하면 base branch(develop) 기준으로 트리거되기 때문에 기존에는 concurrency가 같았습니다.
이를 해결하기 위해 `issue_comment`로 트리거되었을 때, github context에 담겨 넘어오는 `issue.number`에 따라 다른 concurrency를 가지도록 만들었습니다.

## 반영화면
- [빌드 성공](https://github.com/PRNDcompany/heydealer-call-android/pull/311)
- [빌드 실패](https://github.com/PRNDcompany/heydealer-call-android/pull/312)

## 테스트
위 2개의 PR에서 `@tester-prnd build` 호출