### PR TITLE
HDA-10720 [공통] release 빌드하는 workflow 의 gradle task 분리

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,9 @@ jobs:
              ./gradlew assembleQa assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
             ;;
           release)
-             ./gradlew assembleRelease bundleRelease assembleQa assembleQb checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew bundleRelease --gradle-user-home "../../../.gradle"
+             ./gradlew assembleQa assembleQb --gradle-user-home "../../../.gradle"
             ;;
           *)
              ./gradlew assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"


### PR DESCRIPTION
- Release APK, Bundle, QA파일을 한번에 다 만들려고 하다보니 OOM 발생
- https://prnd.slack.com/archives/C9UERACB1/p1698394543393149