### PR TITLE
HDA-10735 [공통][Jenkins -> GitHub Actions 마이그레이션] QA, Release 빌드일 경우 -> S3 임시 폴더에 파일을 업로드

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       ref:
         type: string
         default: ${{ github.ref }}
+      bucket_name:
+        required: false
+        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
@@ -20,6 +23,10 @@ on:
         required: true
       SIGNING_PASSWORD:
         required: true
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
@@ -67,3 +74,17 @@ jobs:
           HEY_DEALER_FOR_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
           HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      - name: Copy to files directory
+        if:  inputs.bucket_name != '' && ( inputs.build_type == 'qa' || inputs.build_type == 'release' )
+        run: |
+          mkdir -p app/build/files
+          find app/build/outputs/ -type f \( -name "*.apk" -o -name "*.aab" \) -exec cp {} app/build/files/ \;
+      - name: Upload Files (temp directory)
+        if:  inputs.bucket_name != '' && ( inputs.build_type == 'qa' || inputs.build_type == 'release' )
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ inputs.bucket_name }}
+          source_dir: "app/build/files"
+          destination_dir: "tmp/${{ inputs.ref }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,4 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ inputs.bucket_name }}
           source_dir: "app/build/files"
-          destination_dir: "tmp/${{ inputs.ref }}"
+          destination_dir: "tmp/${{ github.repository }}/${{ inputs.ref }}"

--- a/.github/workflows/build_app_by_comment.yml
+++ b/.github/workflows/build_app_by_comment.yml
@@ -1,6 +1,10 @@
 name: QA 앱 빌드
 on:
   workflow_call:
+    inputs:
+      bucket_name:
+        required: true
+        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: true
@@ -9,6 +13,10 @@ on:
       SIGNING_NAME:
         required: true
       SIGNING_PASSWORD:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
         required: true
 jobs:
   create-check-run:
@@ -44,11 +52,14 @@ jobs:
     with:
       build_type: qa
       ref: refs/pull/${{ github.event.issue.number }}/merge
+      bucket_name: ${{ inputs.bucket_name }}
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
       SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
       SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   update-check-run:
     runs-on: ubuntu-latest
     needs: [create-check-run, build-app]


### PR DESCRIPTION
- QA, Release 빌드일경우, S3의 `tmp/${{ github.repository }}/${{ inputs.ref }}` 폴더에 임시로 apk/aab 파일을 업로드
- 추후 다음 job에서 QA나 Release의 경로에 맞는 곳으로 move처리

## 알고리즘
1. 빌드후 ouput으로 APK/AAB파일 만들어짐
2. output/files 폴더로 모든 결과물 이동
3. S3의 `tmp/${{ github.repository }}/${{ inputs.ref }}` 경로로 결과물 업로드
## 추후 작업
- https://prndcompany.atlassian.net/browse/HDA-10747