### PR TITLE
HDA-10790 [공통] [workflow] release빌드시 qa빌드 하는 단계 분리

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
           release)
              ./gradlew assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
              ./gradlew bundleRelease --gradle-user-home "../../../.gradle"
-             ./gradlew assembleQa assembleQb --gradle-user-home "../../../.gradle"
             ;;
           *)
              ./gradlew assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"


### PR DESCRIPTION
- build.yml에서 release빌드에서는 qa빌드하는 작업을 제거하고
- 각 앱에서 release 처리하는 workflow에서 release빌드 완료후 qa빌드를 처리하는 방식의 job으로 분리