### PR TITLE
HDA-10827 [공통] Check를 처음 만들 때 in_progress 상태로 생성

### DIFF
--- a/.github/workflows/build_app_by_comment.yml
+++ b/.github/workflows/build_app_by_comment.yml
@@ -51,6 +51,7 @@ jobs:
           repository: ${{ github.repository }}
           name: "build-app-by-comment"
           head_sha: ${{ steps.get_head_sha.outputs.head_sha }}
+          status: "in_progress"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-app:


### PR DESCRIPTION
## 개요

Check를 처음 만들 때, status 값으로 아무것도 넣지 않으면 queued 상태로 생성됩니다.
그러면 실제로 작업을 수행하더라도 계속해서 queued 상태가 되어서 계속 아무 것도 안하는 것으로 오해할 수 있습니다.

실제 상태가 큐에서 대기 중인 경우와 진행 중인 경우 중 작업이 진행중인 경우가 더 많으므로 최초 상태를 in_progress로 생성하도록 변경합니다.