### PR TITLE
HDA-10902 [공통] build 동시성 그룹을 만들 때, issue 번호를 먼저 찾고 없으면 github.ref를 찾도록 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: 빌드
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 on:
   workflow_call:


### PR DESCRIPTION
## 개요
동시성 그룹을 만들 때, `pull_request.number`에 대한 fallback 값 설정으로 `github.ref`가 먼저 처리됩니다.
그로 인해 항상 develop branch를 대상으로 동시성 그룹이 만들어져서 여러 개의 QA 빌드 트리거가 발생하는 경우 관계없는 PR들이어도 같은 동시성 그룹을 가지게 됩니다.

이는 의도했던 바가 아니므로 최초 의도대로 같은 PR별로 다른 동시성 그룹을 가지도록 fallback 값으로 `issue.number`를 먼저 설정하고 마지막으로 `github.ref`로 설정하도록 변경합니다.

## 반영 화면
임시로 default branch를 변경하고 2번 `build QA` 코멘트를 남겨 테스트해보았습니다.

https://github.com/PRNDcompany/heydealer-call-android/actions/runs/6873496821