### PR TITLE
HDA-10897 [공통] QA 빌드 Check 이름 수정

### DIFF
--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           route: POST /repos/{repository}/check-runs
           repository: ${{ github.repository }}
-          name: "build-app-by-comment"
+          name: "build-qa"
           head_sha: ${{ steps.get_head_sha.outputs.head_sha }}
           status: "in_progress"
         env:


### PR DESCRIPTION
## 개요
파일 이름과 job 이름 등등 모든 곳에서 트리거되는 것에 상관없이 수행하는 것에 초점을 맞춰 이름을 짓고 있습니다.
Check를 만드는 곳에서만 누락되어서 여기도 똑같이 수행하는 것에 초점을 맞춰서 `build-qa`로 변경합니다.