### PR TITLE
HDA-11091 [workflow] Release에 배포예정인 Jira이슈 검증 

### DIFF
--- a/.github/workflows/compare_jira_release_by_release_pr.yml
+++ b/.github/workflows/compare_jira_release_by_release_pr.yml
@@ -1,0 +1,43 @@
+name: Compare jira release issue by release PR
+on:
+  workflow_call:
+    inputs:
+      jira_domain:
+        required: true
+        type: string
+      jira_project:
+        required: true
+        type: string
+      jira_version_prefix:
+        required: true
+        type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+      JIRA_AUTH_TOKEN:
+        required: true
+jobs:
+  compare-jira-release-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Jira release issue 비교 by release PR
+        id: compare_jira_release_issue
+        uses: PRNDcompany/compare-jira-release-issue-by-release-pr@0.1
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          jira-token: ${{ secrets.JIRA_AUTH_TOKEN }}
+          jira-domain: ${{ inputs.jira_domain }}
+          jira-project: ${{ inputs.jira_project }}
+          jira-version-prefix: ${{ inputs.jira_version_prefix }}
+      - name: jira issue keys 출력
+        run: |
+          echo ${{ steps.compare_jira_release_issue.outputs.missing_issue_keys }}
+      - name: Create comment
+        if: ${{ steps.compare_jira_release_issue.outputs.missing_issue_keys != '[]' }}
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            @${{ github.event.pull_request.assignee.login }} 이 버전에 포함 예정이었으나, 실제 작업되지 않은 Jira이슈 발견 😱
+            ${{ steps.compare_jira_release_issue.outputs.missing_issue_keys }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## 개요
1. Release PR의 commit에서 배포예정인 Jira key를 뽑아온뒤
2. Release에 정의된 배포예정인 Jira이슈와 비교해서
3. 만약 배포예정으로 나와있는데 실제 commit이 없는 Jira key를 가져오고 comment
https://github.com/PRNDcompany/compare-jira-release-issue-by-release-pr



## 반영화면
https://github.com/PRNDcompany/heydealer-call-android/pull/354#issuecomment-1837918019
![image](https://github.com/PRNDcompany/heydealer-android/assets/37530721/cd052985-1c01-4a0b-a51d-aed49b1719cc)
