### PR TITLE
HDA-11139 [workflow] 모든 빌드 시작전에 clean 처리 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,14 +59,14 @@ jobs:
         run: |
           case "${{ inputs.build_type }}" in
           qa)
-             ./gradlew assembleQa assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew clean assembleQa assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
             ;;
           release)
-             ./gradlew assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew clean assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
              ./gradlew bundleRelease --gradle-user-home "../../../.gradle"
             ;;
           *)
-             ./gradlew assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"
+             ./gradlew clean assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"
             ;;
           esac
         env:


### PR DESCRIPTION
- 각 runner의 build폴더가 계속 쌓이고만 있어서 용량을 크게 차지하고 있음
- 모든 빌드에서 clean을 하고 시작해서 용량을 최적화 하도록 한다.