### PR TITLE
HDA-11475 [workflow] Release에 배포예정인 Jira이슈 검증 버전 최신화

### DIFF
--- a/.github/workflows/compare_jira_release_by_release_pr.yml
+++ b/.github/workflows/compare_jira_release_by_release_pr.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Jira release issue 비교 by release PR
         id: compare_jira_release_issue
-        uses: PRNDcompany/compare-jira-release-issue-by-release-pr@0.3
+        uses: PRNDcompany/compare-jira-release-issue-by-release-pr@0.4
         with:
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           jira-token: ${{ secrets.JIRA_AUTH_TOKEN }}


### PR DESCRIPTION
- commit comment에 Jira key가 중간에 있을때도 extract가능하도록 정규식 수정된 버전 반영
- https://github.com/PRNDcompany/compare-jira-release-issue-by-release-pr/pull/3