### PR TITLE
HDA-11532 [workflow] Release에 배포예정인 Jira이슈 검증 - 로그 남기는 버전 업데이트

### DIFF
--- a/.github/workflows/compare_jira_release_by_release_pr.yml
+++ b/.github/workflows/compare_jira_release_by_release_pr.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Jira release issue 비교 by release PR
         id: compare_jira_release_issue
-        uses: PRNDcompany/compare-jira-release-issue-by-release-pr@0.4
+        uses: PRNDcompany/compare-jira-release-issue-by-release-pr@0.5
         with:
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           jira-token: ${{ secrets.JIRA_AUTH_TOKEN }}


### PR DESCRIPTION
- 커밋 메세지로부터 JIra key를 못가져오는경우가 있는데
- 모든 커밋메세지를 가져오는지, extract를 잘하는지 파악하기 위해 로그 추가된 버전 사용
- https://github.com/PRNDcompany/compare-jira-release-issue-by-release-pr/pull/4