### PR TITLE
HDA-14391 [공통] workflow - Release PR생성시 branch이름에 맞는 PR이름으로 만들어지도록 처리

### DIFF
--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -21,6 +21,9 @@ jobs:
       - name: 버전 정보 추출
         run: echo "version=$(echo ${GITHUB_REF##*/} | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_version
+      - name: 배포 타입 추출
+        id: extract_release_type
+        run: echo "type=$(echo ${GITHUB_REF_NAME} | cut -d'/' -f1)" >> $GITHUB_ENV
       - name: Jira 릴리즈 노트 추출
         id: release_notes
         uses: PRNDcompany/jira-release-notes@0.7
@@ -36,7 +39,7 @@ jobs:
           destination_branch: ${{ inputs.main_branch_name }}
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
-          pr_title: "Release ${{ steps.extract_version.outputs.version }}"
+          pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
       - name: Release PR 생성 (develop)
         uses: repo-sync/pull-request@v2
@@ -44,5 +47,5 @@ jobs:
           destination_branch: "develop"
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           pr_assignee: ${{ github.event.head_commit.author.name }}
-          pr_title: "Release ${{ steps.extract_version.outputs.version }} -> develop"
+          pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"


### PR DESCRIPTION
- 현재: 배포시 만들어지는 PR이름이 항상 Release xxx 로 되어 있음
- 변경: release, hotfix branch에 맞게 release xxx 혹은 hotfix xxx 로 표시되도록 변경

1. `GITHUB_REF_NAME` = `release/1.0.0` or `hotfix/1.0/1`
2. `GITHUB_REF_NAME`로부터 앞의 이름을 가져옴
3. PR을 만들때 title에 2번의 값을 사용하여 넣도록 수정

## 결과
- release 1.0.0
- release 1.0.0 -> develop

