### PR TITLE
HDA-14353 [공통] hotfix이면 PR을 draft 상태로 생성

### DIFF
--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -41,6 +41,7 @@ jobs:
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
+          pr_draft: ${{ inputs.main_branch_name == 'hotfix' }}
       - name: Release PR 생성 (develop)
         uses: repo-sync/pull-request@v2
         with:
@@ -49,3 +50,4 @@ jobs:
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"
+          pr_draft: ${{ inputs.main_branch_name == 'hotfix' }}


### PR DESCRIPTION
## 개요
hotfix PR은 draft 상태로 만들어지도록 변경합니다.

[repo-sync/pull-request 공식문서](https://github.com/repo-sync/pull-request/tree/v2.12.1?tab=readme-ov-file#advanced-options)

## 반영 화면
임시 repository에서 테스트해보았습니다.

![스크린샷 2024-08-28 17 51 46](https://github.com/user-attachments/assets/72cc2084-5111-4ee0-9ef0-e5b52753ec44)
![스크린샷 2024-08-28 17 51 19](https://github.com/user-attachments/assets/f15426cb-2036-4cf7-84dc-d10857116301)
