### PR TITLE
HDA-14353 [공통] hotfix이면 PR을 draft 상태로 생성

### DIFF
--- a/.github/workflows/release_pr_create.yml
+++ b/.github/workflows/release_pr_create.yml
@@ -41,7 +41,7 @@ jobs:
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }}"
           pr_body: "# ${{ steps.release_notes.outputs.release_notes_url }}\n\n\n${{ steps.release_notes.outputs.release_notes }}"
-          pr_draft: ${{ inputs.main_branch_name == 'hotfix' }}
+          pr_draft: ${{ steps.extract_release_type.outputs.type == 'hotfix' }}
       - name: Release PR 생성 (develop)
         uses: repo-sync/pull-request@v2
         with:
@@ -50,4 +50,4 @@ jobs:
           pr_assignee: ${{ github.event.head_commit.author.name }}
           pr_title: "${{ steps.extract_release_type.outputs.type }} ${{ steps.extract_version.outputs.version }} -> develop"
           pr_body: "${{steps.create_pr.outputs.pr_url}}"
-          pr_draft: ${{ inputs.main_branch_name == 'hotfix' }}
+          pr_draft: ${{ steps.extract_release_type.outputs.type == 'hotfix' }}


### PR DESCRIPTION
## 개요
https://github.com/PRNDcompany/prnd-android-workflows/pull/70
위 PR에서 잘못 구현한 부분을 수정합니다.

`main_branch_name`은 develop 또는 main과 같이 base가 되는 branch 입니다. release인지 hotfix인지에 대한 여부는 extract_release_type에서 type으로 반환하고 있습니다.