### PR TITLE
HDA-14472 [workflow] main PR이 ready 상태가 되면 develop PR도 ready 상태로 변경

### DIFF
--- a/.github/workflows/release_pr_develop_ready.yml
+++ b/.github/workflows/release_pr_develop_ready.yml
@@ -1,0 +1,20 @@
+name: Release PR develop ready
+
+on:
+  workflow_call:
+
+jobs:
+  pr_develop_ready:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: develop PR을 ready for review로 변경
+        run: |
+          PR_NUMBER=$(gh pr list --base develop --head "$GITHUB_HEAD_REF" --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr ready $PR_NUMBER
+          else
+            echo "develop PR을 찾지 못했습니다."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 개요 
main이 base인 PR이 ready for review 상태가 되면 develop이 base인 PR도 ready for review 상태로 변경합니다.

## 반영 화면
![image](https://github.com/user-attachments/assets/b311bf57-4948-40c9-9607-28257fe41a20)

## 테스트
main을 base로 하는 PR에서 ready for review를 눌러서 테스트

- [main PR](https://github.com/PRNDcompany/heydealer-call-android/pull/404)
- [develop PR](https://github.com/PRNDcompany/heydealer-call-android/pull/405)