### PR TITLE
HDA-14493 [workflow] release branch 생성할 때, src/main/kotlin 디렉토리도 처리되도록 개선

### DIFF
--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -24,8 +24,19 @@ jobs:
 
       - name: VersionCode 추출후 +1 / 환경변수에 등록
         run: |
+          # Dependencies.kt 파일 경로 찾기
+          if [ -f buildSrc/src/main/java/Dependencies.kt ]; then
+            dependencies_file_path="buildSrc/src/main/java/Dependencies.kt"
+          elif [ -f buildSrc/src/main/kotlin/Dependencies.kt ]; then
+            dependencies_file_path="buildSrc/src/main/kotlin/Dependencies.kt"
+          else
+            echo "Dependencies.kt 파일을 찾을 수 없습니다."
+            exit 1
+          fi
+          echo "DEPENDENCIES_FILE_PATH=$dependencies_file_path" >> $GITHUB_ENV
+
           version_name=${{ inputs.version_name }}
-          version_code=$(grep "versionCode" buildSrc/src/main/java/Dependencies.kt | awk '{print $4}' | tr -d '\n')
+          version_code=$(grep "versionCode" $dependencies_file_path | awk '{print $4}' | tr -d '\n')
           # 새로운 versionCode 생성
           new_version_code=$((version_code + 1))
           echo "$version_code -> $new_version_code"
@@ -38,8 +49,8 @@ jobs:
       - name: 파일에 VersionCode/VersionName 변경
         run: |
           echo "${{ env.VERSION_CODE }} - ${{ env.VERSION_NAME }}"
-          sed -i "s/versionCode = [0-9]\+/versionCode = ${{ env.VERSION_CODE }}/g" buildSrc/src/main/java/Dependencies.kt
-          sed -i "s/versionName = \"[^\"]*\"/versionName = \"${{ env.VERSION_NAME }}\"/g" buildSrc/src/main/java/Dependencies.kt
+          sed -i "s/versionCode = [0-9]\+/versionCode = ${{ env.VERSION_CODE }}/g" ${{ env.DEPENDENCIES_FILE_PATH }}
+          sed -i "s/versionName = \"[^\"]*\"/versionName = \"${{ env.VERSION_NAME }}\"/g" ${{ env.DEPENDENCIES_FILE_PATH }}
           
       - name: Commit & Push
         run: |


### PR DESCRIPTION
## 개요
`Dependencies.kt` 파일 위치가 `src/main/java`로 고정되어 있어서 `src/main/kotlin`에 있는 경우 실패합니다.
이를 해결하기 위해 2개 디렉토리 위치 모두 동작하도록 개선합니다.

## 반영 화면
- [workflow 실행 결과](https://github.com/PRNDcompany/revolt-android/actions/runs/10630337583/job/29469010533)
- [커밋](https://github.com/PRNDcompany/revolt-android/commit/5dee6e57996c3121bf85a045bb426b8e69350e98)