### PR TITLE
HDA-16220 [workflow] octokit/request-action의 버전을 찾을 수 없는 버그 수정

### DIFF
--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -53,7 +53,7 @@ jobs:
       check_run_id: ${{ fromJson(steps.create_check_run.outputs.data).id }}
     steps:
       - name: Check Run 생성
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # 2.4.0
         id: create_check_run
         with:
           route: POST /repos/{repository}/check-runs
@@ -107,7 +107,7 @@ jobs:
     if: always()
     steps:
       - name: Check Run 동기화
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # 2.4.0
         with:
           route: PATCH /repos/{repository}/check-runs/{check_run_id}
           repository: ${{ github.repository }}


### PR DESCRIPTION
## 개요
`octokit/request-action`을 버전으로 가져올 수는 없는데 commit id를 명시하면 가져올 수 있다고 합니다. ([참고](https://github.com/octokit/request-action/issues/315#issuecomment-2650484778))
이에 따라 주석으로만 버전명을 명시하고 commit id를 사용하도록 변경합니다.

