### PR TITLE
HDA-16430 [workflow] branch가 feature-base로 시작하는 PR은 debug 빌드 skip

### DIFF
--- a/.github/workflows/check_skip.yml
+++ b/.github/workflows/check_skip.yml
@@ -7,5 +7,6 @@ jobs:
     if: |
       github.event.pull_request.draft == false 
       && !contains(github.event.pull_request.title, 'skip-ci')
+      && !startsWith(github.head_ref, 'feature-base')
     steps:
       - run: echo "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## 개요
회고에서 결정된 Try에 따라 `feature-base`로 시작하는 PR은 debug 빌드를 skip합니다.

* [Problem](https://www.notion.so/feature-base-PR-1a7177dc09bf8022a7d7f56da9263d9a?pvs=4)
* [Try](https://www.notion.so/feature-base-PR-skip-1ac177dc09bf80c0b05bef93111ec33e?pvs=4)

## 반영화면
