### PR TITLE
HDA-16770 [workflow] release 빌드 할 때 catalog 앱은 bundle 하지 않도록 변경

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,10 @@ jobs:
         run: |
           case "${{ inputs.build_type }}" in
           qa)
-             ./gradlew clean assembleQa assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
             ;;
           release)
-             ./gradlew clean assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+             ./gradlew clean :app:assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
              ./gradlew :app:bundleRelease --gradle-user-home "../../../.gradle"
             ;;
           *)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             ;;
           release)
              ./gradlew clean assembleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
-             ./gradlew bundleRelease --gradle-user-home "../../../.gradle"
+             ./gradlew :app:bundleRelease --gradle-user-home "../../../.gradle"
             ;;
           *)
              ./gradlew assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"


### PR DESCRIPTION
## 개요
- release 빌드 할 때 app 모듈 외에 prnd-catalog가 항상 같이 apk, aab가 만들어집니다.
: https://github.com/PRNDcompany/prnd-android-workflows/blob/main/.github/workflows/build.yml
- 실제로는 app 모듈과 관련한 내용만 쓰고 있기 때문에 명시적으로 :app 모듈만 빌드하도록 수정합니다. 