### PR TITLE
HDA-16774 [공통] workflow - 개발/QA/Release 빌드 workflow 분리

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -1,0 +1,33 @@
+name: Debug 빌드
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ${{ github.ref }}
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+jobs:
+  check-skip:
+    uses: ./.github/workflows/check_skip.yml
+  build:
+    runs-on: Android # self-hosted runner
+    needs: check-skip
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build with Gradle
+        # 현재 위치: runner/_work/repo_name/repo_name
+        # gradle user home 위치: runner/.gradle
+        run: ./gradlew assembleDebug checkDebugUnitTest  --gradle-user-home "../../../.gradle"
+        env:
+          BRANCH_NAME: ${{ github.ref }}

--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
-  build:
+  build-debug:
     runs-on: Android # self-hosted runner
     needs: check-skip
     steps:

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -1,4 +1,7 @@
 name: QA 빌드
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
 on:
   workflow_call:
     inputs:
@@ -64,19 +67,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-qa:
+    runs-on: Android # self-hosted runner
     needs: create-check-run
-    uses: ./.github/workflows/build.yml
-    with:
-      build_type: qa
-      ref: refs/pull/${{ github.event.issue.number }}/merge
-      bucket_name: ${{ inputs.bucket_name }}
-    secrets:
-      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
-      SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/merge
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Decode KeyStore File
+        id: decode_key_store_file
+        env:
+          KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
+        run: |
+          KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
+          echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
+
+          echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
+      - name: Build with Gradle
+        # 현재 위치: runner/_work/repo_name/repo_name
+        # gradle user home 위치: runner/.gradle
+        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+        env:
+          HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          BRANCH_NAME: ${{ github.ref }}
+      - name: Copy to files directory
+        run: |
+          mkdir -p app/build/files
+          find app/build/outputs/ -type f \( -name "*.apk" -o -name "*.aab" \) -exec cp {} app/build/files/ \;
+      - name: Upload Files (temp directory)
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ inputs.bucket_name }}
+          source_dir: "app/build/files"
+          destination_dir: "tmp/${{ github.repository }}/refs/pull/${{ github.event.issue.number }}/merge"
+
 
   move_s3_qa:
     needs: [ get-pr, build-qa ]

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Build with Gradle
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
-        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+        run: |
+          ./gradlew clean :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+          ./gradlew app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build with Gradle
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
-        run: ./gradlew clean :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -54,7 +54,8 @@ jobs:
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
         run: |
-          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+          GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -54,8 +54,7 @@ jobs:
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
         run: |
-          ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
-          ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,88 @@
+name: Release 빌드
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ${{ github.ref }}
+      bucket_name:
+        required: false
+        type: string
+      extra_task:
+        required: false
+        type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+      KEY_STORE_FILE:
+        required: true
+      SIGNING_NAME:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+jobs:
+  check-skip:
+    uses: ./.github/workflows/check_skip.yml
+  build:
+    runs-on: Android # self-hosted runner
+    needs: check-skip
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Decode KeyStore File
+        id: decode_key_store_file
+        env:
+          KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
+        run: |
+          KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
+          echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
+
+          echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
+      - name: Build with Gradle
+        # 현재 위치: runner/_work/repo_name/repo_name
+        # gradle user home 위치: runner/.gradle
+        run: ./gradlew clean :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+        env:
+          HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          BRANCH_NAME: ${{ github.ref }}
+      - name: Extra gradle task
+        if: inputs.extra_task != ''
+        run: |
+          ./gradlew ${{ inputs.extra_task }} --gradle-user-home "../../../.gradle"
+        env:
+          HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
+          HEY_DEALER_FOR_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}
+          HEY_DEALER_FOR_DEALER_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          BRANCH_NAME: ${{ github.ref }}
+      - name: Copy to files directory
+        run: |
+          mkdir -p app/build/files
+          find app/build/outputs/ -type f \( -name "*.apk" -o -name "*.aab" \) -exec cp {} app/build/files/ \;
+      - name: Upload Files (temp directory)
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ inputs.bucket_name }}
+          source_dir: "app/build/files"
+          destination_dir: "tmp/${{ github.repository }}/${{ inputs.ref }}"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -54,8 +54,8 @@ jobs:
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
         run: |
-          ./gradlew clean :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
-          ./gradlew app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+          ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+          ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
-  build:
+  build-release:
     runs-on: Android # self-hosted runner
     needs: check-skip
     steps:


### PR DESCRIPTION


## 개요
- 명확하게 개발/QA/Release 빌드일때 필요한 task가 다르므로 다른 yml로 분리해서 사용되도록 한다.
- Release 빌드의 task를 1개로 합친다. 
: https://prnd.slack.com/archives/C9UERACB1/p1743569087862559
- QA빌드도 Release 빌드할때 한번의 task에서 함께 한다.

## 작업사항
- Debug 빌드랑만 관련있는 workflow 생성 
: 기존 build.yml을 그대로 복사한뒤 QA/Release 빌드와 관련있는 step은 제거
- Release 빌드랑만 관련있는 workflow 생성 
: 기존 build.yml을 그대로 복사한뒤 build_type 관련 사용하는 코드 제거
- QA 빌드 과정을 기존 build_qa 파일안에 추가 
: 기존 build.yml을 그대로 복사한뒤 build_type 관련된 코드 제거 ref 를 직접 넣어줌
- release 빌드할때 qa빌드도 한번에 모두 하도록 통합 

