### PR TITLE
HDA-16775 [공통] workflow - QA/Release 빌드 runs-on 분리

### DIFF
--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -93,9 +93,6 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
       - name: Decode KeyStore File
         id: decode_key_store_file
         env:

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build with Gradle
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
-        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
+        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -103,7 +103,7 @@ jobs:
 
           echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
-        run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest
+        run: ./gradlew :app:assembleQa :app:assembleQb checkQaUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -75,8 +75,27 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/merge
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+
+      # 모든 프로젝트에서 동일한 key를 갖도록 gradle-wrapper.jar 파일을 해싱하여 사용
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.jar') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
       - name: Decode KeyStore File
         id: decode_key_store_file
         env:

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-qa:
-    runs-on: Android # self-hosted runner
+    runs-on: ubuntu-latest-8core
     needs: create-check-run
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -106,8 +106,6 @@ jobs:
 
           echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
-        # 현재 위치: runner/_work/repo_name/repo_name
-        # gradle user home 위치: runner/.gradle
         run: ./gradlew clean :app:assembleQa :app:assembleQb checkQaUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -70,8 +70,6 @@ jobs:
 
           echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
-        # 현재 위치: runner/_work/repo_name/repo_name
-        # gradle user home 위치: runner/.gradle
         run: |
           GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest
           GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -31,7 +31,7 @@ jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
   build-release:
-    runs-on: Android # self-hosted runner
+    runs-on: ubuntu-latest-8core
     needs: check-skip
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,8 +39,27 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+
+      # 모든 프로젝트에서 동일한 key를 갖도록 gradle-wrapper.jar 파일을 해싱하여 사용
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.jar') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
       - name: Decode KeyStore File
         id: decode_key_store_file
         env:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -68,7 +68,7 @@ jobs:
           echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
         run: |
-          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest
+          GRADLE_OPTS="-Xmx16g" ./gradlew app:assembleQa :app:assembleQb checkQaUnitTest
           GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -73,8 +73,8 @@ jobs:
         # 현재 위치: runner/_work/repo_name/repo_name
         # gradle user home 위치: runner/.gradle
         run: |
-          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest --gradle-user-home "../../../.gradle"
-          GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest --gradle-user-home "../../../.gradle"
+          GRADLE_OPTS="-Xmx16g" ./gradlew clean app:assembleQa :app:assembleQb checkQaUnitTest
+          GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -57,9 +57,6 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
       - name: Decode KeyStore File
         id: decode_key_store_file
         env:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -68,8 +68,8 @@ jobs:
           echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
       - name: Build with Gradle
         run: |
-          GRADLE_OPTS="-Xmx16g" ./gradlew app:assembleQa :app:assembleQb checkQaUnitTest
-          GRADLE_OPTS="-Xmx16g" ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest
+          ./gradlew :app:assembleQa :app:assembleQb checkQaUnitTest
+          ./gradlew :app:assembleRelease :app:bundleRelease checkReleaseUnitTest
         env:
           HEY_DEALER_SIGNING_PATH: ${{ steps.decode_key_store_file.outputs.key_store_file_path }}
           HEY_DEALER_SIGNING_NAME: ${{ secrets.SIGNING_NAME }}


### PR DESCRIPTION
## 개요
- QA/Release 빌드는 self host runner가 아닌 GitHub Actions의 runner를 사용하도록 변경
: https://prnd.slack.com/archives/C9UERACB1/p1743564034581079

## 작업사항
- QA/Release 빌드는 runs-on을 8core의 Large runner를 사용하도록 변경
- Gradle/Java 설정 step 추가 
: GitHub-hosted runner는 이미 Android SDK가 설치되어 있음