### PR TITLE
HDA-16794 [공통] workflow - 빌드관련 job의 이름을 모두 build로 통일

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
-  build-debug:
+  build:
     runs-on: Android # self-hosted runner
     needs: check-skip
     steps:

--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -66,7 +66,7 @@ jobs:
           status: "in_progress"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-qa:
+  build:
     runs-on: Android # self-hosted runner
     needs: create-check-run
     steps:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   check-skip:
     uses: ./.github/workflows/check_skip.yml
-  build-release:
+  build:
     runs-on: Android # self-hosted runner
     needs: check-skip
     steps:


### PR DESCRIPTION
- 불필요하게 job의 이름을 build-xxx 로 분리하지 않고 build로만 통일
- 여러 Repository에서 check의 이름과 관련된것들이 build 이름을 바라보고 있는데 구지 분리할 필요 없으므로 통일

