### PR TITLE
HDA-16795 [공통] workflow - keystore decode관련 코드 정정

### DIFF
--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -102,10 +102,12 @@ jobs:
         env:
           KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
         run: |
-          KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
+          KEYSTORE_DIR="$RUNNER_TEMP/keystore"
+          mkdir -p "$KEYSTORE_DIR"
+          KEY_STORE_FILE_PATH="$KEYSTORE_DIR/keystore.jks"
           echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
 
-          echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
+          echo "$KEY_STORE_FILE" | base64 --decode > "$KEY_STORE_FILE_PATH"
       - name: Build with Gradle
         run: |
           if [ "${{ inputs.build_type }}" = "qa" ]; then

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -62,10 +62,12 @@ jobs:
         env:
           KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
         run: |
-          KEY_STORE_FILE_PATH=$(echo $RUNNER_TEMP/keystore)
+          KEYSTORE_DIR="$RUNNER_TEMP/keystore"
+          mkdir -p "$KEYSTORE_DIR"
+          KEY_STORE_FILE_PATH="$KEYSTORE_DIR/keystore.jks"
           echo "key_store_file_path=$KEY_STORE_FILE_PATH" >> "$GITHUB_OUTPUT"
 
-          echo $KEY_STORE_FILE | base64 --decode > $KEY_STORE_FILE_PATH
+          echo "$KEY_STORE_FILE" | base64 --decode > "$KEY_STORE_FILE_PATH"
       - name: Build with Gradle
         run: |
           ./gradlew :app:assembleQa :app:assembleQb checkQaUnitTest


### PR DESCRIPTION
## 개요
- large runner를 이용해서 keystore를 decode할때 오류 발생
: https://github.com/PRNDcompany/heydealer-android/actions/runs/14235337332/job/39893553608 
- 정확한 원인은 모르겠으나 self host와 github action runner의 플랫폼 차이 인것 같음
- 명확하게 따옴표(“) 추가하고 jks 파일 path로 설정해줘서 잘 동작하도록 처리

