### PR TITLE
HDA-16957 [workflow] QA 빌드 동시성 오류 수정

### DIFF
--- a/.github/workflows/build_qa.yml
+++ b/.github/workflows/build_qa.yml
@@ -1,7 +1,4 @@
 name: QA 빌드
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
 on:
   workflow_call:
     inputs:
@@ -73,6 +70,9 @@ jobs:
   build:
     runs-on: Android # self-hosted runner
     needs: create-check-run
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## 개요
`build_qa.yml`의 concurrency group을 만들 때 `github.event.pull_request.number`와 `github.event.issue.number`가 둘 다 존재 하지 않아서 `issue_comment`가 트리거된 develop을 기준으로 만들어지게 됩니다.

기존에 `build.yml`을 호출하던 때에는 해당 job을 대상으로 concurrency group이 생성되었습니다.
이전처럼 `build` job을 대상으로 concurrency group을 생성하도록 변경합니다.

## 반영 화면

https://github.com/PRNDcompany/heydealer-call-android/actions/runs/14509096374
![스크린샷 2025-04-17 15 00 17](https://github.com/user-attachments/assets/95da21a7-be87-4cd9-aece-163f967edb05)
