### PR TITLE
HDA-16819 [workflow] release, hotfix 브랜치에서 debug 빌드 skip

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -18,6 +18,8 @@ jobs:
       github.event.pull_request.draft == false
       && !contains(github.event.pull_request.title, 'skip-ci')
       && !startsWith(github.head_ref, 'feature-base')
+      && !startsWith(github.head_ref, 'release')
+      && !startsWith(github.head_ref, 'hotfix')
     steps:
       - name: check-skip
         run: echo "" # no-op


### PR DESCRIPTION
## 개요

release, hotfix 브랜치는 불필요하게 debug 빌드를 하지 않도록 개선합니다.

## 반영 화면
- [release - skip O](https://github.com/PRNDcompany/heydealer-call-android/actions/runs/14529977051?pr=436)
- [hotfix - skip O](https://github.com/PRNDcompany/heydealer-call-android/actions/runs/14529978891?pr=437)
- [feature - skip X](https://github.com/PRNDcompany/heydealer-call-android/actions/runs/14529975336?pr=438)

![스크린샷 2025-04-18 14 04 33](https://github.com/user-attachments/assets/bd74fe21-ada0-44fc-aa72-061906e8f69b)
![스크린샷 2025-04-18 14 04 37](https://github.com/user-attachments/assets/5c45d00c-2545-43d6-bacd-c815bd1f9ddb)
![스크린샷 2025-04-18 14 04 42](https://github.com/user-attachments/assets/db0bd5d0-9184-4b8b-909d-7226f9565779)
